### PR TITLE
Added support for Manjaro

### DIFF
--- a/src/browser/browser_base.py
+++ b/src/browser/browser_base.py
@@ -5,25 +5,26 @@ import filesystem
 
 class BrowserBase(ABC):
     def __init__(this):
-        this.application_name = None
+        this.possible_application_names = None
         this.possible_tab_locations = None
 
     @abstractmethod
     def is_running(this) -> bool:
         """
-        Checks if this browser is running by searching for the `application_name`
+        Checks if this browser is running by searching for the `possible_application_names`
         within the active programs.
 
         Returns:
             true if the process is detected to be active, false if not.
         """
-        if this.application_name is None:
+        if this.possible_application_names is None:
             raise NotImplementedError()
 
         for process in process_iter():
             try:
-                if this.application_name in process.name():
-                    return True
+                for name in this.possible_application_names:
+                    if name in process.name():
+                        return True
             except (NoSuchProcess, AccessDenied, ZombieProcess):
                 pass
         return False

--- a/src/browser/firefox.py
+++ b/src/browser/firefox.py
@@ -7,9 +7,14 @@ from browser.browser_base import BrowserBase
 class Firefox(BrowserBase):
     def __init__(this):
         super().__init__()
-        this.application_name = "GeckoMain"
-        this.possible_tab_locations = [
+        this.possible_application_names = [
             # Firefox GNU/Linux (Ubuntu & Fedora tested)
+            "GeckoMain",
+            # Firefox GNU/Linux (Manjaro tested)
+            "firefox"
+        ]
+        this.possible_tab_locations = [
+            # Firefox GNU/Linux (Ubuntu, Fedora & Manjaro tested)
             "~/.mozilla/firefox*/*.default*/sessionstore-backups/recovery.jsonlz4",
         ]
 


### PR DESCRIPTION
Added support for Manjaro which required support for another name for the Firefox process, since the other distros used a synonym.

Todo;
- [x] Test on my other systems (Ubuntu / Fedora)