### PR TITLE
Moved over to typed mozilla lz4 decoder

### DIFF
--- a/browser/browser_firefox.go
+++ b/browser/browser_firefox.go
@@ -3,7 +3,7 @@ package browser
 import (
 	"log/slog"
 
-	"gitlab.com/Electrenator/mozilla-lz4-decoder/mozillaLz4"
+	"gitlab.com/electrenator/mozilla-lz4-decoder/mozillaLz4"
 )
 
 type FirefoxBrowser struct {
@@ -41,7 +41,7 @@ func (browser *FirefoxBrowser) GetherWindowData() []WindowInfo {
 	var windowData []WindowInfo
 
 	for _, path := range browser.getSessionStorageLocation() {
-		jsonValues, err := mozillaLz4.Read(path)
+		browserData, err := mozillaLz4.Read(path)
 		if err != nil {
 			// Already logged in above function!
 			slog.Error(
@@ -52,9 +52,9 @@ func (browser *FirefoxBrowser) GetherWindowData() []WindowInfo {
 			continue
 		}
 
-		resultWindows := make([]WindowInfo, len(jsonValues.Windows))
+		resultWindows := make([]WindowInfo, len(browserData.Windows))
 
-		for i, window := range jsonValues.Windows {
+		for i, window := range browserData.Windows {
 			resultWindows[i] = WindowInfo{len(window.Tabs)}
 		}
 		windowData = append(windowData, resultWindows...)

--- a/browser/browser_firefox.go
+++ b/browser/browser_firefox.go
@@ -1,15 +1,9 @@
 package browser
 
 import (
-	"encoding/json"
-	"fmt"
 	"log/slog"
-	"os"
 
-	"github.com/dustin/go-humanize"
-	"github.com/electrenator/tabbly/util"
-	"github.com/giulianopz/go-dejsonlz4/jsonlz4"
-	"github.com/itchyny/gojq"
+	"gitlab.com/Electrenator/mozilla-lz4-decoder/mozillaLz4"
 )
 
 type FirefoxBrowser struct {
@@ -47,77 +41,24 @@ func (browser *FirefoxBrowser) GetherWindowData() []WindowInfo {
 	var windowData []WindowInfo
 
 	for _, path := range browser.getSessionStorageLocation() {
-		jsonValues, err := parseSessionBackup(path)
+		jsonValues, err := mozillaLz4.Read(path)
 		if err != nil {
 			// Already logged in above function!
+			slog.Error(
+				"Error while parsing session file",
+				"path", path,
+				"error", err,
+			)
 			continue
 		}
 
-		query, err := gojq.Parse(".windows | map(.tabs | length)")
-		if err != nil {
-			slog.Error("Unable to parse jq", "error", err)
-			continue
+		resultWindows := make([]WindowInfo, len(jsonValues.Windows))
+
+		for i, window := range jsonValues.Windows {
+			resultWindows[i] = WindowInfo{len(window.Tabs)}
 		}
-
-		resultIterator := query.Run(jsonValues)
-		for {
-			resultItem, ok := resultIterator.Next()
-			if !ok {
-				break
-			}
-
-			resultValues := util.ConvertSlice[int](resultItem.([]any))
-			resultWindows := make([]WindowInfo, len(resultValues))
-
-			for i, tab := range resultValues {
-				resultWindows[i] = WindowInfo{tab}
-			}
-			windowData = append(windowData, resultWindows...)
-		}
+		windowData = append(windowData, resultWindows...)
 	}
 
 	return windowData
-}
-
-// Parses the Firefox backup session file.
-func parseSessionBackup(path string) (map[string]any, error) {
-	fileData, err := os.ReadFile(path)
-	if err != nil {
-		slog.Error(
-			"Can't read file",
-			"path", path,
-			"error", err,
-		)
-		return nil, err
-	}
-
-	data, err := jsonlz4.Uncompress(fileData)
-	if err != nil {
-		slog.Error(
-			"Can't decompress file for reading",
-			"path", path,
-			"error", err,
-		)
-		return nil, err
-	}
-	slog.Info(fmt.Sprintf(
-		"Decompressed %s of size %s (%s uncompressed)",
-		path,
-		humanize.IBytes(uint64(len(fileData))),
-		humanize.IBytes(uint64(len(data))),
-	))
-
-	jsonValues := make(map[string]any)
-	// Following operation somehow massively increases application memory usage
-	// What's happening in that Unmarshal that makes the application go from ±11
-	// to 75MiB (depending on session file) at sleep back in main?
-	if err := json.Unmarshal(data, &jsonValues); err != nil {
-		slog.Error(
-			"Can't json decode file",
-			"file", path,
-			"error", err,
-		)
-		return nil, err
-	}
-	return jsonValues, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,15 @@ go 1.24.0
 
 require (
 	github.com/dustin/go-humanize v1.0.1
-	github.com/giulianopz/go-dejsonlz4 v0.0.0-20250310212005-3e2e5dfb85f4
-	github.com/itchyny/gojq v0.12.17
 	github.com/mattn/go-sqlite3 v1.14.27
 	github.com/shirou/gopsutil/v4 v4.25.3
 	github.com/spf13/pflag v1.0.6
+	gitlab.com/Electrenator/mozilla-lz4-decoder v0.0.0-20250416195428-38d20dca42a8
 )
 
 require (
 	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.27
 	github.com/shirou/gopsutil/v4 v4.25.3
 	github.com/spf13/pflag v1.0.6
-	gitlab.com/Electrenator/mozilla-lz4-decoder v0.0.0-20250416195428-38d20dca42a8
+	gitlab.com/electrenator/mozilla-lz4-decoder v0.1.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfj
 github.com/tklauser/numcpus v0.10.0/go.mod h1:BiTKazU708GQTYF4mB+cmlpT2Is1gLk7XVuEeem8LsQ=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-gitlab.com/Electrenator/mozilla-lz4-decoder v0.0.0-20250416195428-38d20dca42a8 h1:o0CE9pufWRHiaoqBrClW25PIzVsi80e6ewzIUaohTJ0=
-gitlab.com/Electrenator/mozilla-lz4-decoder v0.0.0-20250416195428-38d20dca42a8/go.mod h1:yrcssf5zDowxptUKwD29m4WKSALyPtOP+wLSi1w85H8=
+gitlab.com/electrenator/mozilla-lz4-decoder v0.1.2 h1:Vl8I0f3MfiGWoyQFd7N+L4n174kwxnpJsFZGHIchw7k=
+gitlab.com/electrenator/mozilla-lz4-decoder v0.1.2/go.mod h1:3KcErumQETJyGeUEXocygAs6UtgQkcULxizb3JpUaO0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -4,17 +4,11 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
 github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/giulianopz/go-dejsonlz4 v0.0.0-20250310212005-3e2e5dfb85f4 h1:CaRP6XnyzXDdnXksKosMAybQYiz6gGtDAyy1ND6cPcs=
-github.com/giulianopz/go-dejsonlz4 v0.0.0-20250310212005-3e2e5dfb85f4/go.mod h1:o5AsymoKBdWuMknX2JFUaw8BvzbttQE8lcVJIhq5fqM=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
-github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
-github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=
-github.com/itchyny/timefmt-go v0.1.6/go.mod h1:RRDZYC5s9ErkjQvTvvU7keJjxUYzIISJGxm9/mAERQg=
 github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 h1:PpXWgLPs+Fqr325bN2FD2ISlRRztXibcX6e8f5FR5Dc=
 github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/mattn/go-sqlite3 v1.14.27 h1:drZCnuvf37yPfs95E5jd9s3XhdVWLal+6BOK6qrv6IU=
@@ -37,6 +31,8 @@ github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfj
 github.com/tklauser/numcpus v0.10.0/go.mod h1:BiTKazU708GQTYF4mB+cmlpT2Is1gLk7XVuEeem8LsQ=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+gitlab.com/Electrenator/mozilla-lz4-decoder v0.0.0-20250416195428-38d20dca42a8 h1:o0CE9pufWRHiaoqBrClW25PIzVsi80e6ewzIUaohTJ0=
+gitlab.com/Electrenator/mozilla-lz4-decoder v0.0.0-20250416195428-38d20dca42a8/go.mod h1:yrcssf5zDowxptUKwD29m4WKSALyPtOP+wLSi1w85H8=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Replaced Firefox jsonlz4 parser with my own [mozilla-lz4-decoder library](https://gitlab.com/Electrenator/mozilla-lz4-decoder/mozillaLz4) which also handles parse testing. Using this the dependency on gojq and go-dejsonlz4 can be dropped.

This experiment has minimal memory reduction but does make working with the jsonlz4 file easier without knowledge of it. Implementation is still a bit experimental given that mozilla-lz4-decoder has not fully been battle tested yet.

